### PR TITLE
Values outside min/max range don't lead to weird drawing anymore

### DIFF
--- a/src/Gauge.js
+++ b/src/Gauge.js
@@ -16,6 +16,9 @@ export default class Gauge extends Component {
 	};
 
 	_getPathValues = (value) => {
+		if (value < this.props.min) value = this.props.min;
+		if (value > this.props.max) value = this.props.max;
+
 		var dx = 0;
 		var dy = 0;
 		var gws = 1;


### PR DESCRIPTION
Just added a small fix that draws the gauge with min or max level if the value is outside the range.