### PR TITLE
Allow use of this lib without synthetic default imports

### DIFF
--- a/src/Gauge.tsx
+++ b/src/Gauge.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 //global unique key for every gauge (needed for SVG groups to stay separated)
 let uniqueId = 0;


### PR DESCRIPTION
Because the lib was built with synthetical default imports it previously `import React from 'react';` which is not compatible with projects that do not use synthetic default imports.

By changing this to `import * as React from 'react';` I believe this will now be compatible with projects regardless of whether they have enabled synthetic default imports.